### PR TITLE
allow graceful exit

### DIFF
--- a/src/complexplot/ComplexplotWrapper.cpp
+++ b/src/complexplot/ComplexplotWrapper.cpp
@@ -42,6 +42,10 @@ ComplexplotWrapper::ComplexplotWrapper()
 
 ComplexplotWrapper::~ComplexplotWrapper()
 {
+  if(QCoreApplication::instance() == NULL) {
+    destroyed_ = true;
+  }
+
   if(destroyed_)
     emit destroyWidgetSignal();
   else

--- a/src/keyvalue/KeyValueWrapper.cpp
+++ b/src/keyvalue/KeyValueWrapper.cpp
@@ -39,6 +39,10 @@ KeyValueWrapper::KeyValueWrapper()
 
 KeyValueWrapper::~KeyValueWrapper()
 {
+  if(QCoreApplication::instance() == NULL) {
+    destroyed_ = true;
+  }
+
   if(destroyed_)
     emit destroyWidgetSignal();
   else

--- a/src/realplot/RealplotWrapper.cpp
+++ b/src/realplot/RealplotWrapper.cpp
@@ -38,6 +38,10 @@ RealplotWrapper::RealplotWrapper()
 
 RealplotWrapper::~RealplotWrapper()
 {
+  if(QCoreApplication::instance() == NULL) {
+    destroyed_ = true;
+  }
+
   if(destroyed_)
     emit destroyWidgetSignal();
   else

--- a/src/scatterplot/ScatterplotWrapper.cpp
+++ b/src/scatterplot/ScatterplotWrapper.cpp
@@ -42,6 +42,10 @@ ScatterplotWrapper::ScatterplotWrapper()
 
 ScatterplotWrapper::~ScatterplotWrapper()
 {
+  if(QCoreApplication::instance() == NULL) {
+    destroyed_ = true;
+  }
+
   if(destroyed_)
     emit destroyWidgetSignal();
   else

--- a/src/srsgui++.cpp
+++ b/src/srsgui++.cpp
@@ -4,14 +4,16 @@
 #include <unistd.h>
 
 pthread_t threadxx;
+QApplication* appxx;
 static int sdrgui_initiatedxx=0;
 
 void *qt_threadxx(void *arg)
 {
   int argc = 1;
   char* argv[] = { const_cast<char *>((char*) arg), NULL };
-  QApplication app(argc, argv);
-  app.exec();
+  appxx = new QApplication(argc, argv);
+  appxx->exec();
+  delete appxx;
   pthread_exit(NULL);
 }
 
@@ -41,8 +43,11 @@ void sdrgui_exit() {
   if(sdrgui_initiatedxx)
   {
     usleep(100000);
-    pthread_cancel(threadxx);
+    if(appxx) {
+        appxx->quit();
+    }
+
     pthread_join(threadxx, NULL);
-	}
+  }
   sdrgui_initiatedxx=0;
 }

--- a/src/srsgui.cpp
+++ b/src/srsgui.cpp
@@ -5,14 +5,16 @@
 #include <unistd.h>
 
 pthread_t thread;
+QApplication* app;
 static int sdrgui_initiated=0;
 
 void *qt_thread(void *arg)
 {
 	int argc = 1;
 	char* argv[] = { const_cast<char *>((char*) arg), NULL };
-  QApplication app(argc, argv);
-	app.exec();
+    app = new QApplication(argc, argv);
+    app->exec();
+    delete app;
 	pthread_exit(NULL);
 }
 
@@ -43,8 +45,10 @@ void sdrgui_exit()
   if(sdrgui_initiated)
   {
     usleep(100000);
-		pthread_cancel(thread);
-        pthread_join(thread, NULL);
-	}
+    if (app) {
+        app->quit();
+    }
+    pthread_join(thread, NULL);
+  }
   sdrgui_initiated=0;
 }

--- a/src/textedit/TextEditWrapper.cpp
+++ b/src/textedit/TextEditWrapper.cpp
@@ -39,6 +39,10 @@ TextEditWrapper::TextEditWrapper()
 
 TextEditWrapper::~TextEditWrapper()
 {
+  if(QCoreApplication::instance() == NULL) {
+    destroyed_ = true;
+  }
+
   if(destroyed_)
     emit destroyWidgetSignal();
   else

--- a/src/waterfallplot/WaterfallplotWrapper.cpp
+++ b/src/waterfallplot/WaterfallplotWrapper.cpp
@@ -39,6 +39,10 @@ WaterfallplotWrapper::WaterfallplotWrapper(int numDataPoints, int numRows)
 
 WaterfallplotWrapper::~WaterfallplotWrapper()
 {
+  if(QCoreApplication::instance() == NULL) {
+    destroyed_ = true;
+  }
+
   if(destroyed_)
     emit destroyWidgetSignal();
   else


### PR DESCRIPTION
Two commits to allow for a graceful exit:

Commit 1: Without the commit, we get the following error when running tests:
```
# ./waterfallplot_test_c
Qt has caught an exception thrown from an event handler. Throwing
exceptions from an event handler is not supported in Qt.
You must not let any exception whatsoever propagate through Qt code.
If that is not possible, in Qt 5 you must at least reimplement
QCoreApplication::notify() and catch all exceptions there.
```

Commit 2: check if the application was closed (e.g. using a close button). Without this commit, it tries to send a blocking signal to destroy a widget and hangs as there is no app to receive it.