### PR TITLE
Make minor correction to the instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For instance in ubuntu you can run: ```sudo apt-get install libboost-system-dev 
 Finally, to download and build srsGUI, just run: 
 ```
 git clone https://github.com/srsLTE/srsGUI.git
-cd srsgui
+cd srsGUI
 mkdir build
 cd build
 cmake ../


### PR DESCRIPTION
Fix instructions so that the `srsGUI` directory name has accurate capitalization. Avoids an annoyance if you copy this code block into a terminal and it crashes because "srsgui" does not exist.